### PR TITLE
IPNet: More benchmarks, profiling, and prototyping a faster version

### DIFF
--- a/Benchmarks.sln
+++ b/Benchmarks.sln
@@ -1,24 +1,42 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26228.4
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29806.167
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmarks", "Benchmarks\Benchmarks.csproj", "{32E53332-78D1-48CD-B185-3982A2DF0ABF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks", "Benchmarks\Benchmarks.csproj", "{32E53332-78D1-48CD-B185-3982A2DF0ABF}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A6B4E7A1-67A3-426B-B580-088572AE7545}"
 	ProjectSection(SolutionItems) = preProject
 		Benchmarks.bat = Benchmarks.bat
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Profiling", "Profiling\Profiling.csproj", "{2BB01D9C-6C61-426D-B1B4-C83F7C6420FE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "Tests\Tests.csproj", "{2508BFD0-D38D-4DAE-BB9E-B5B43B73E15B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{32E53332-78D1-48CD-B185-3982A2DF0ABF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32E53332-78D1-48CD-B185-3982A2DF0ABF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{32E53332-78D1-48CD-B185-3982A2DF0ABF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{32E53332-78D1-48CD-B185-3982A2DF0ABF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2BB01D9C-6C61-426D-B1B4-C83F7C6420FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2BB01D9C-6C61-426D-B1B4-C83F7C6420FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2BB01D9C-6C61-426D-B1B4-C83F7C6420FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2BB01D9C-6C61-426D-B1B4-C83F7C6420FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2508BFD0-D38D-4DAE-BB9E-B5B43B73E15B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2508BFD0-D38D-4DAE-BB9E-B5B43B73E15B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2508BFD0-D38D-4DAE-BB9E-B5B43B73E15B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2508BFD0-D38D-4DAE-BB9E-B5B43B73E15B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8C04EE7B-E053-403F-9AF4-13030672E505}
 	EndGlobalSection
 EndGlobal

--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.1.6" />

--- a/Benchmarks/IPNetSpan.cs
+++ b/Benchmarks/IPNetSpan.cs
@@ -1,0 +1,33 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using Benchmarks.Libs;
+using System.Net;
+
+namespace Benchmarks
+{
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+    [CategoriesColumn]
+    [Config(typeof(Config))]
+    public class IPNetSpanTests
+    {
+        private static readonly IPAddress LocalIp = IPAddress.Parse("127.0.0.1");
+        [Benchmark, BenchmarkCategory("Orig")] public void IPAddressParsev4() => IPAddress.Parse("127.0.0.1");
+        //[Benchmark, BenchmarkCategory("Orig")] public void IPAddressParsev6() => IPAddress.Parse("::1");
+
+        [Benchmark, BenchmarkCategory("Orig")] public void IPAddressTryParsev4() => IPAddress.TryParse("127.0.0.1", out var _);
+        //[Benchmark, BenchmarkCategory("Orig")] public void IPAddressTryParsev6() => IPAddress.TryParse("::1", out var _);
+
+        //[Benchmark, BenchmarkCategory("Orig")] public void IPNetCostructor() => new IPNetOriginal(LocalIp, null);
+        [Benchmark, BenchmarkCategory("Span")] public void IPNetSpanCostructor() => new IPNet(LocalIp);
+
+        //[Benchmark, BenchmarkCategory("Orig")] public void IPNetParsev4() => IPNetOriginal.Parse("127.0.0.1");
+        [Benchmark, BenchmarkCategory("Span")] public void IPNetSpanParsev4() => IPNet.Parse("127.0.0.1");
+        //[Benchmark, BenchmarkCategory("Orig")] public void IPNetCidrv4() => IPNetOriginal.Parse("127.0.0.1/16");
+        [Benchmark, BenchmarkCategory("Span")] public void IPNetSpanCidrv4() => IPNet.Parse("127.0.0.1/24");
+
+        //[Benchmark, BenchmarkCategory("Orig")] public void IPNetParsev6() => IPNetOriginal.Parse("::1");
+        [Benchmark, BenchmarkCategory("Span")] public void IPNetSpanParsev6() => IPNet.Parse("::1");
+        //[Benchmark, BenchmarkCategory("Orig")] public void IPNetCidrv6() => IPNetOriginal.Parse("::1/96");
+        [Benchmark, BenchmarkCategory("Span")] public void IPNetSpanCidrv6() => IPNet.Parse("::1/96");
+    }
+}

--- a/Benchmarks/Libs/ByteUtil.cs
+++ b/Benchmarks/Libs/ByteUtil.cs
@@ -1,0 +1,54 @@
+﻿#if NETCOREAPP
+using System;
+
+namespace Benchmarks.Libs
+{
+    public static class ByteUtil
+    {
+        // An idea from vcsjones, via https://gist.github.com/vcsjones/35823b7131dce67c0e6ed9145aaad1a4
+        public static bool TryParse(ReadOnlySpan<char> str, out byte result)
+        {
+            result = 0;
+
+            int b = 0, ch, i = 0;
+            switch (str.Length)
+            {
+                case 3:
+                    goto Three;
+                case 2:
+                    goto Two;
+                case 1:
+                    goto One;
+                default:
+                    return false;
+            }
+
+        Three:
+            ch = str[i] - '0';
+            if (ch > 9)
+                return false;
+            b = 100 * ch;
+            i++;
+
+        Two:
+            ch = str[i] - '0';
+            if (ch > 9)
+                return false;
+            b += 10 * ch;
+            i++;
+
+        One:
+            ch = str[i] - '0';
+            if (ch > 9)
+                return false;
+            b += ch;
+
+            if (b > byte.MaxValue)
+                return false;
+
+            result = (byte)b;
+            return true;
+        }
+    }
+}
+#endif

--- a/Benchmarks/Libs/IPNet.cs
+++ b/Benchmarks/Libs/IPNet.cs
@@ -144,7 +144,7 @@ namespace Benchmarks.Libs
             var slashPos = span.IndexOf('/');
             if (slashPos > -1)
             {
-                if (byte.TryParse(span.Slice(slashPos + 1), out var cidr))
+                if (ByteUtil.TryParse(span.Slice(slashPos + 1), out var cidr))
                 {
                     return Parse(span.Slice(0, slashPos), cidr);
                 }

--- a/Benchmarks/Libs/IPNetOriginal.cs
+++ b/Benchmarks/Libs/IPNetOriginal.cs
@@ -6,56 +6,34 @@ using System.Net.Sockets;
 using System.Runtime.Serialization;
 using System.Text;
 
-#nullable enable
 namespace Benchmarks.Libs
 {
-    public class IPNet
+    public class IPNetOriginal
     {
-        private static IPAddress[] KnownIPv4Subsets { get; } = CalcSubnets(AddressFamily.InterNetwork);
-        private static IPAddress[] KnownIPv6Subsets { get; } = CalcSubnets(AddressFamily.InterNetworkV6);
-
-        private static IPAddress[] CalcSubnets(AddressFamily family)
-        {
-            var bitLength = GetBitLength(family);
-            var subnets = new IPAddress[bitLength + 1];
-#if NETCOREAPP
-            Span<byte> ipByteArray = stackalloc byte[bitLength / 8];
-#else
-            var ipByteArray = new byte[bitLength / 8];
-#endif
-            subnets[0] = new IPAddress(ipByteArray);
-            // Loop through and set bits left to right (shifting the high bit per iteration)
-            for (byte position = 0; position < bitLength; position++)
-            {
-                ipByteArray[Math.DivRem(position, 8, out var remainder)] |= (byte)(0x80 >> remainder);
-                subnets[position + 1] = new IPAddress(ipByteArray);
-            }
-            return subnets;
-        }
-
         public IPAddress IPAddress { get; }
         public IPAddress Subnet { get; }
-        public byte CIDR { get; }
+        public int CIDR { get; }
         public AddressFamily AddressFamily => IPAddress.AddressFamily;
 
         public string AddressFamilyDescription =>
             IPAddress.AddressFamily == AddressFamily.InterNetwork
                 ? "IPv4"
                 : IPAddress.AddressFamily == AddressFamily.InterNetworkV6
-                    ? "IPv6"    
+                    ? "IPv6"
                     : "";
 
-        private TinyIPAddress? _tinyIPAddress;
-        internal TinyIPAddress TIPAddress =>
-            _tinyIPAddress ??= TinyIPAddress.FromIPAddress(IPAddress);
+        private TinyIPAddress? _tinyIPAddress { get; set; }
+        private TinyIPAddress? _tinySubnet { get; set; }
 
-        private TinyIPAddress? _tinySubnet;
+        internal TinyIPAddress TIPAddress =>
+            (_tinyIPAddress ??= TinyIPAddress.FromIPAddress(IPAddress)).Value;
+
         internal TinyIPAddress TSubnet =>
-            _tinySubnet ??= TinyIPAddress.FromIPAddress(Subnet ?? IPAddress);
+            (_tinySubnet ??= TinyIPAddress.FromIPAddress(Subnet ?? IPAddress)).Value;
 
         public IPAddress FirstAddressInSubnet => TinyFirstAddressInSubnet.ToIPAddress();
         public IPAddress LastAddressInSubnet => TinyLastAddressInSubnet.ToIPAddress();
-        public IPAddress? Broadcast => AddressFamily == AddressFamily.InterNetwork ? TinyBroadcast.ToIPAddress() : null;
+        public IPAddress Broadcast => AddressFamily == AddressFamily.InterNetwork ? TinyBroadcast.ToIPAddress() : null;
 
         private TinyIPAddress TinyFirstAddressInSubnet => TIPAddress & TSubnet;
         private TinyIPAddress TinyLastAddressInSubnet => Subnet == null ? TIPAddress : (TIPAddress | ~TSubnet);
@@ -75,10 +53,10 @@ namespace Benchmarks.Libs
                 return false;
             }
             var tip = TinyIPAddress.FromIPAddress(ip);
-            return Contains(tip);
+            return tip.HasValue && Contains(tip.Value);
         }
 
-        public bool Contains(IPNet network) =>
+        public bool Contains(IPNetOriginal network) =>
             network != null
             && AddressFamily == network.AddressFamily
             && TinyFirstAddressInSubnet <= network.TinyFirstAddressInSubnet
@@ -87,39 +65,30 @@ namespace Benchmarks.Libs
         private bool Contains(TinyIPAddress tip) =>
             AddressFamily == tip.AddressFamily && (TSubnet & TIPAddress) == (TSubnet & tip);
 
-        public static bool IsPrivateNetwork(IPNet network) =>
+        public static bool IsPrivateNetwork(IPNetOriginal network) =>
             ReservedPrivateRanges.Any(r => r.Contains(network));
 
-        public static bool IsMulticastNetwork(IPNet network) =>
+        public static bool IsMulticastNetwork(IPNetOriginal network) =>
             ReservedMulticastRanges.Any(r => r.Contains(network));
 
-        public static bool IsLinkLocalNetwork(IPNet network) =>
+        public static bool IsLinkLocalNetwork(IPNetOriginal network) =>
             ReservedLinkLocalRanges.Any(r => r.Contains(network));
 
-        public static bool IsDocumentationNetwork(IPNet network) =>
+        public static bool IsDocumentationNetwork(IPNetOriginal network) =>
             ReservedDocumentationRanges.Any(r => r.Contains(network));
 
-        public IPNet(IPAddress ip, byte? cidr = null)
-        {
-            IPAddress = ip;
-            CIDR = cidr ?? (byte)GetBitLength(ip.AddressFamily);
-            Subnet = IPAddressFromCIDR(ip.AddressFamily, CIDR);
-        }
-
-        public IPNet(IPAddress ip, IPAddress subnet) : this (ip, subnet, subnetKnownValid: false) { }
-
-        private IPNet(IPAddress ip, IPAddress subnet, bool subnetKnownValid = false)
+        public IPNetOriginal(IPAddress ip, IPAddress subnet, int? cidr = null)
         {
             IPAddress = ip;
             Subnet = subnet;
-            if (!subnetKnownValid && subnet != null && !TSubnet.IsValidSubnet)
+            if (subnet != null && !TSubnet.IsValidSubnet)
             {
                 throw new IPNetParseException("Error: subnet mask '{0}' is not a valid subnet", subnet);
             }
-            CIDR = (byte)(subnet == null ? GetBitLength(ip.AddressFamily) : TSubnet.NumberOfSetBits);
+            CIDR = cidr ?? (subnet == null ? GetBitLength(ip.AddressFamily) : TSubnet.NumberOfSetBits);
         }
 
-        public static bool TryParse(string ipOrCidr, out IPNet? net)
+        public static bool TryParse(string ipOrCidr, out IPNetOriginal net)
         {
             try
             {
@@ -133,42 +102,27 @@ namespace Benchmarks.Libs
             }
         }
 
-#if !NETCOREAPP
         private static readonly char[] _forwardSlash = new[] { '/' };
-#endif
 
-        public static IPNet Parse(string ipOrCidr)
+        public static IPNetOriginal Parse(string ipOrCidr)
         {
-#if NETCOREAPP
-            ReadOnlySpan<char> span = ipOrCidr;
-            var slashPos = span.IndexOf('/');
-            if (slashPos > -1)
-            {
-                if (byte.TryParse(span.Slice(slashPos + 1), out var cidr))
-                {
-                    return Parse(span.Slice(0, slashPos), cidr);
-                }
-                throw new IPNetParseException("Error parsing CIDR from IP: '" + ipOrCidr + "'");
-            }
-#else
             var parts = ipOrCidr.Split(_forwardSlash);
             if (parts.Length == 2)
             {
-                if (byte.TryParse(parts[1], out var cidr))
+                if (int.TryParse(parts[1], out int cidr))
                 {
                     return Parse(parts[0], cidr);
                 }
                 throw new IPNetParseException("Error parsing CIDR from IP: '{0}'", parts[1]);
             }
-#endif
             if (IPAddress.TryParse(ipOrCidr, out var ip))
             {
-                return new IPNet(ip);
+                return new IPNetOriginal(ip, null);
             }
             throw new IPNetParseException("Error parsing IP Address from IP: '{0}'", ipOrCidr);
         }
 
-        public static bool TryParse(string ip, byte cidr, out IPNet? net)
+        public static bool TryParse(string ip, int cidr, out IPNetOriginal net)
         {
             try
             {
@@ -182,26 +136,30 @@ namespace Benchmarks.Libs
             }
         }
 
-        public static IPNet Parse(string ip, byte cidr)
+        public static IPNetOriginal Parse(string ip, int cidr)
         {
             if (IPAddress.TryParse(ip, out var ipAddr))
             {
-                return new IPNet(ipAddr, cidr);
+                var bits = GetBitLength(ipAddr.AddressFamily);
+                var subnet = IPAddressFromCIDR(bits, cidr);
+                return new IPNetOriginal(ipAddr, subnet, cidr);
             }
             throw new IPNetParseException("Error parsing IP Address from IP: '{0}'", ip);
         }
 #if NETCOREAPP
-        public static IPNet Parse(ReadOnlySpan<char> ip, byte cidr)
+        public static IPNetOriginal Parse(ReadOnlySpan<char> ip, int cidr)
         {
             if (IPAddress.TryParse(ip, out var ipAddr))
             {
-                return new IPNet(ipAddr, cidr);
+                var bits = GetBitLength(ipAddr.AddressFamily);
+                var subnet = IPAddressFromCIDR(bits, cidr);
+                return new IPNetOriginal(ipAddr, subnet, cidr);
             }
             throw new IPNetParseException("Error parsing IP Address from IP: '" + ip.ToString() + "'");
         }
 #endif
 
-        public static bool TryParse(string ip, string subnet, out IPNet? net)
+        public static bool TryParse(string ip, string subnet, out IPNetOriginal net)
         {
             try
             {
@@ -215,17 +173,17 @@ namespace Benchmarks.Libs
             }
         }
 
-        public static IPNet Parse(string ip, string subnet)
+        public static IPNetOriginal Parse(string ip, string subnet)
         {
             if (IPAddress.TryParse(ip, out var ipAddr))
             {
                 if (IPAddress.TryParse(subnet, out var subnetAddr))
                 {
-                    if (!(TinyIPAddress.FromIPAddress(subnetAddr)?.IsValidSubnet ?? false))
+                    if (!TinyIPAddress.FromIPAddress(subnetAddr).Value.IsValidSubnet)
                     {
                         throw new IPNetParseException("Error parsing subnet mask Address from IP: '" + subnet + "' is not a valid subnet");
                     }
-                    return new IPNet(ipAddr, subnetAddr, subnetKnownValid: true);
+                    return new IPNetOriginal(ipAddr, subnetAddr);
                 }
                 throw new IPNetParseException("Error parsing subnet mask from IP: '" + subnet + "'");
             }
@@ -233,7 +191,7 @@ namespace Benchmarks.Libs
         }
 
         public static IPAddress ToNetmask(AddressFamily addressFamily, int cidr) =>
-            IPAddressFromCIDR(addressFamily, cidr);
+            IPAddressFromCIDR(GetBitLength(addressFamily), cidr);
 
         private static int GetBitLength(AddressFamily family) =>
             family switch
@@ -244,31 +202,30 @@ namespace Benchmarks.Libs
             };
 
         // This is a much faster version thanks to Marc Gravell
-        private static IPAddress IPAddressFromCIDR(AddressFamily family, int cidr)
+        private static IPAddress IPAddressFromCIDR(int bitLength, int cidr)
         {
-            switch (family)
+#if NETCOREAPP
+            Span<byte> ipByteArray = stackalloc byte[bitLength / 8];
+#else
+            var ipByteArray = new byte[bitLength / 8];
+#endif
+            int fullBytes = cidr / 8, lastBits = cidr % 8;
+            for (var i = 0; i < fullBytes; i++)
             {
-                case AddressFamily.InterNetwork:
-                    if (cidr <= KnownIPv4Subsets.Length)
-                    {
-                        return KnownIPv4Subsets[cidr];
-                    }
-                    break;
-                case AddressFamily.InterNetworkV6:
-                    if (cidr <= KnownIPv6Subsets.Length)
-                    {
-                        return KnownIPv6Subsets[cidr];
-                    }
-                    break;
+                ipByteArray[i] = 0xff;
             }
-            throw new Exception("Invalid subnet CIDR length: " + cidr);
+            if (lastBits != 0)
+            {
+                ipByteArray[fullBytes] = (byte)~((byte)0xFF >> lastBits);
+            }
+            return new IPAddress(ipByteArray);
         }
 
         /// <summary>
         /// Private IP Ranges reserved for internal use by ARIN
         /// These networks should not route on the global Internet
         /// </summary>
-        private static readonly List<IPNet> ReservedPrivateRanges = new List<IPNet>
+        private static readonly List<IPNetOriginal> ReservedPrivateRanges = new List<IPNetOriginal>
             {
                 Parse("10.0.0.0/8"),
                 Parse("127.0.0.0/8"),
@@ -284,7 +241,7 @@ namespace Benchmarks.Libs
         /// <summary>
         /// Multicast IP Ranges reserved for use by ARIN
         /// </summary>
-        private static readonly List<IPNet> ReservedMulticastRanges = new List<IPNet>
+        private static readonly List<IPNetOriginal> ReservedMulticastRanges = new List<IPNetOriginal>
             {
                 Parse("224.0.0.0/4"),
                 Parse("ff00::/8"),
@@ -293,7 +250,7 @@ namespace Benchmarks.Libs
         /// <summary>
         /// Link-local IP Ranges reserved for use by ARIN
         /// </summary>
-        private static readonly List<IPNet> ReservedLinkLocalRanges = new List<IPNet>
+        private static readonly List<IPNetOriginal> ReservedLinkLocalRanges = new List<IPNetOriginal>
             {
                 Parse("169.254.0.0/16"),
                 Parse("fe80::/10"),
@@ -303,7 +260,7 @@ namespace Benchmarks.Libs
         /// <summary>
         /// Documentation IP Ranges reserved for use by ARIN
         /// </summary>
-        private static readonly List<IPNet> ReservedDocumentationRanges = new List<IPNet>
+        private static readonly List<IPNetOriginal> ReservedDocumentationRanges = new List<IPNetOriginal>
             {
                 Parse("192.0.2.0/24"),    // TEST-NET-1
                 Parse("198.51.100.0/24"), // TEST-NET-2
@@ -320,32 +277,28 @@ namespace Benchmarks.Libs
         }
 
         [DataContract]
-        public class TinyIPAddress : IEquatable<TinyIPAddress>, IComparable<TinyIPAddress>
+        public struct TinyIPAddress : IEquatable<TinyIPAddress>, IComparable<TinyIPAddress>
         {
             [DataMember(Order = 1)]
-            private readonly bool IsV4;
+            private readonly uint? IPv4Address;
             [DataMember(Order = 2)]
-            private readonly bool IsV6;
+            private readonly ulong? FirstV6Leg;
             [DataMember(Order = 3)]
-            private readonly uint IPv4Address;
-            [DataMember(Order = 4)]
-            private readonly ulong FirstV6Leg;
-            [DataMember(Order = 5)]
-            private readonly ulong LastV6Leg;
+            private readonly ulong? LastV6Leg;
 
-            public AddressFamily AddressFamily => IsV4 ? AddressFamily.InterNetwork : AddressFamily.InterNetworkV6;
+            public AddressFamily AddressFamily => IPv4Address.HasValue ? AddressFamily.InterNetwork : AddressFamily.InterNetworkV6;
 
             public string BitString
             {
                 get
                 {
                     StringBuilder sb;
-                    if (IsV4)
+                    if (IPv4Address.HasValue)
                     {
                         sb = StringBuilderCache.Get(32);
                         for (var i = 0; i < 32; i++)
                         {
-                            sb.Append((IPv4Address >> (31 - i)) & 1);
+                            sb.Append((IPv4Address.Value >> (31 - i)) & 1);
                         }
                     }
                     else
@@ -353,11 +306,11 @@ namespace Benchmarks.Libs
                         sb = StringBuilderCache.Get(128);
                         for (var i = 0; i < 64; i++)
                         {
-                            sb.Append((FirstV6Leg >> (63 - i)) & 1);
+                            sb.Append((FirstV6Leg.Value >> (63 - i)) & 1);
                         }
                         for (var i = 0; i < 64; i++)
                         {
-                            sb.Append((LastV6Leg >> (63 - i)) & 1);
+                            sb.Append((LastV6Leg.Value >> (63 - i)) & 1);
                         }
                     }
                     return sb.ToStringRecycle();
@@ -366,106 +319,69 @@ namespace Benchmarks.Libs
 
             public IPAddress ToIPAddress()
             {
-                if (IsV4)
+                if (IPv4Address.HasValue)
                 {
-#if NETCOREAPP
-                    Span<byte> ipArr = stackalloc byte[4] {
-#else
-                    var ipArr = new byte[4] {
-#endif
-                        (byte)(IPv4Address >> 24),
-                        (byte)(IPv4Address >> 16),
-                        (byte)(IPv4Address >> 8),
-                        (byte)(IPv4Address)
-                    };
-                    return new IPAddress(ipArr);
+                    return new IPAddress(new[] {
+                        (byte)(IPv4Address.Value >> 24),
+                        (byte)(IPv4Address.Value >> 16),
+                        (byte)(IPv4Address.Value >> 8),
+                        (byte)(IPv4Address.Value)
+                    });
                 }
-                else
+                if (FirstV6Leg.HasValue && LastV6Leg.HasValue)
                 {
-#if NETCOREAPP
-                    Span<byte> ipArr = stackalloc byte[16] {
-#else
-                    var ipArr = new byte[16] {
-#endif
-                        (byte)(FirstV6Leg >> 56),
-                        (byte)(FirstV6Leg >> 48),
-                        (byte)(FirstV6Leg >> 40),
-                        (byte)(FirstV6Leg >> 32),
-                        (byte)(FirstV6Leg >> 24),
-                        (byte)(FirstV6Leg >> 16),
-                        (byte)(FirstV6Leg >> 8),
-                        (byte)(FirstV6Leg),
-                        (byte)(LastV6Leg >> 56),
-                        (byte)(LastV6Leg >> 48),
-                        (byte)(LastV6Leg >> 40),
-                        (byte)(LastV6Leg >> 32),
-                        (byte)(LastV6Leg >> 24),
-                        (byte)(LastV6Leg >> 16),
-                        (byte)(LastV6Leg >> 8),
-                        (byte)(LastV6Leg)
-                    };
-                    return new IPAddress(ipArr);
+                    return new IPAddress(new[] {
+                        (byte)(FirstV6Leg.Value >> 56),
+                        (byte)(FirstV6Leg.Value >> 48),
+                        (byte)(FirstV6Leg.Value >> 40),
+                        (byte)(FirstV6Leg.Value >> 32),
+                        (byte)(FirstV6Leg.Value >> 24),
+                        (byte)(FirstV6Leg.Value >> 16),
+                        (byte)(FirstV6Leg.Value >> 8),
+                        (byte)(FirstV6Leg.Value),
+                        (byte)(LastV6Leg.Value >> 56),
+                        (byte)(LastV6Leg.Value >> 48),
+                        (byte)(LastV6Leg.Value >> 40),
+                        (byte)(LastV6Leg.Value >> 32),
+                        (byte)(LastV6Leg.Value >> 24),
+                        (byte)(LastV6Leg.Value >> 16),
+                        (byte)(LastV6Leg.Value >> 8),
+                        (byte)(LastV6Leg.Value)
+                    });
                 }
+                return null;
             }
 
-            public TinyIPAddress(uint ipv4Address)
+            public TinyIPAddress(uint? ipv4Address)
             {
-                IsV4 = true;
-                IsV6 = false;
                 IPv4Address = ipv4Address;
-                FirstV6Leg = 0;
-                LastV6Leg = 0;
+                FirstV6Leg = null;
+                LastV6Leg = null;
             }
 
-            public TinyIPAddress(ulong ipv6FirstLeg, ulong ipv6LastLeg)
+            public TinyIPAddress(ulong? ipv6FirstLeg, ulong? ipv6LastLeg)
             {
-                IsV4 = false;
-                IsV6 = true;
-                IPv4Address = 0;
+                IPv4Address = null;
                 FirstV6Leg = ipv6FirstLeg;
                 LastV6Leg = ipv6LastLeg;
             }
 
-            public static TinyIPAddress FromIPAddress(IPAddress addr)
+            public static TinyIPAddress? FromIPAddress(IPAddress addr)
             {
-#if NETCOREAPP
-                Span<byte> source = stackalloc byte[GetBitLength(addr.AddressFamily) / 8];
-                addr.TryWriteBytes(source, out var len);
-#else
                 var source = addr.GetAddressBytes();
-                var len = source.Length;
-#endif
-                if (len == 4)
+                if (source.Length == 4)
                 {
                     return new TinyIPAddress(((uint)source[0] << 24)
-                                           | ((uint)source[1] << 16)
-                                           | ((uint)source[2] << 8)
-                                           | ((uint)source[3]));
+                                             | ((uint)source[1] << 16)
+                                             | ((uint)source[2] << 8)
+                                             | ((uint)source[3]));
                 }
-                if (len == 16)
+                if (source.Length == 16)
                 {
-#if NETCOREAPP
-                    return new TinyIPAddress(FromBytes(source), FromBytes(source.Slice(8)));
-#else
-                    return new TinyIPAddress(FromBytes(source, 0), FromBytes(source, 0));
-#endif
+                    return new TinyIPAddress(FromBytes(source, 0), FromBytes(source, 8));
                 }
-                throw new ArgumentOutOfRangeException(nameof(addr), "Invalid IP Addressed passed: " + addr?.ToString());
+                return null;
             }
-
-#if NETCOREAPP
-            private static ulong FromBytes(ReadOnlySpan<byte> source)
-            {
-                return ((ulong)source[0] << 56)
-                      | ((ulong)source[1] << 48)
-                      | ((ulong)source[2] << 40)
-                      | ((ulong)source[3] << 32)
-                      | ((ulong)source[4] << 24)
-                      | ((ulong)source[5] << 16)
-                      | ((ulong)source[6] << 8)
-                      | ((ulong)source[7]);
-            }
-#endif
 
             private static ulong FromBytes(byte[] source, int start)
             {
@@ -483,13 +399,13 @@ namespace Benchmarks.Libs
             {
                 get
                 {
-                    if (IsV4)
+                    if (IPv4Address.HasValue)
                     {
-                        return NumberOfSetBitsImpl(IPv4Address);
+                        return NumberOfSetBitsImpl(IPv4Address.Value);
                     }
-                    if (IsV6)
+                    if (FirstV6Leg.HasValue && LastV6Leg.HasValue)
                     {
-                        return NumberOfSetBitsImpl(FirstV6Leg) + NumberOfSetBitsImpl(LastV6Leg);
+                        return NumberOfSetBitsImpl(FirstV6Leg.Value) + NumberOfSetBitsImpl(LastV6Leg.Value);
                     }
                     return 0;
                 }
@@ -523,14 +439,14 @@ namespace Benchmarks.Libs
             {
                 get
                 {
-                    if (IsV4)
+                    if (IPv4Address.HasValue)
                     {
-                        return IsValidSubnetImpl(IPv4Address);
+                        return IsValidSubnetImpl(IPv4Address.Value);
                     }
-                    if (IsV6)
+                    if (FirstV6Leg.HasValue && LastV6Leg.HasValue)
                     {
-                        return (FirstV6Leg == ulong.MaxValue && IsValidSubnetImpl(LastV6Leg))
-                           || (LastV6Leg == ulong.MinValue && IsValidSubnetImpl(FirstV6Leg));
+                        return (FirstV6Leg == ulong.MaxValue && IsValidSubnetImpl(LastV6Leg.Value))
+                           || (LastV6Leg == ulong.MinValue && IsValidSubnetImpl(FirstV6Leg.Value));
                     }
                     return false;
                 }
@@ -571,32 +487,32 @@ namespace Benchmarks.Libs
             }
 
             public static TinyIPAddress operator &(TinyIPAddress a, TinyIPAddress b) =>
-                a.IsV4 && b.IsV4
+                a.IPv4Address.HasValue && b.IPv4Address.HasValue
                     ? new TinyIPAddress(a.IPv4Address & b.IPv4Address)
                     : new TinyIPAddress(a.FirstV6Leg & b.FirstV6Leg, a.LastV6Leg & b.LastV6Leg);
 
             public static TinyIPAddress operator |(TinyIPAddress a, TinyIPAddress b) =>
-                a.IsV4 && b.IsV4
+                a.IPv4Address.HasValue && b.IPv4Address.HasValue
                     ? new TinyIPAddress(a.IPv4Address | b.IPv4Address)
                     : new TinyIPAddress(a.FirstV6Leg | b.FirstV6Leg, a.LastV6Leg | b.LastV6Leg);
 
             public static TinyIPAddress operator +(TinyIPAddress a, TinyIPAddress b) =>
-                a.IsV4 && b.IsV4
+                a.IPv4Address.HasValue && b.IPv4Address.HasValue
                     ? new TinyIPAddress(a.IPv4Address + b.IPv4Address)
                     : new TinyIPAddress(a.FirstV6Leg + b.FirstV6Leg, a.LastV6Leg + b.LastV6Leg);
 
             public static TinyIPAddress operator ~(TinyIPAddress a) =>
-                a.IsV4
+                a.IPv4Address.HasValue
                     ? new TinyIPAddress(~a.IPv4Address)
                     : new TinyIPAddress(~a.FirstV6Leg, ~a.LastV6Leg);
 
             public static bool operator ==(TinyIPAddress a, TinyIPAddress b) =>
-                (a.IsV4 && b.IsV4 && a.IPv4Address == b.IPv4Address)
-                || (a.IsV6 && b.IsV6 && a.FirstV6Leg == b.FirstV6Leg && a.LastV6Leg == b.LastV6Leg);
+                (a.IPv4Address.HasValue && b.IPv4Address.HasValue && a.IPv4Address == b.IPv4Address)
+                || (a.FirstV6Leg.HasValue && b.FirstV6Leg.HasValue && a.FirstV6Leg == b.FirstV6Leg && a.LastV6Leg == b.LastV6Leg);
 
             public static bool operator !=(TinyIPAddress a, TinyIPAddress b) =>
-                (a.IsV4 && b.IsV4 && a.IPv4Address != b.IPv4Address)
-                || (a.IsV6 && b.IsV6 && (a.FirstV6Leg != b.FirstV6Leg || a.LastV6Leg != b.LastV6Leg));
+                (a.IPv4Address.HasValue && b.IPv4Address.HasValue && a.IPv4Address != b.IPv4Address)
+                || (a.FirstV6Leg.HasValue && b.FirstV6Leg.HasValue && (a.FirstV6Leg != b.FirstV6Leg || a.LastV6Leg != b.LastV6Leg));
 
             public static bool operator <(TinyIPAddress a, TinyIPAddress b) => Compare(a, b) < 0;
             public static bool operator >(TinyIPAddress a, TinyIPAddress b) => Compare(a, b) > 0;
@@ -605,7 +521,7 @@ namespace Benchmarks.Libs
 
             public override int GetHashCode()
             {
-                if (IsV4)
+                if (IPv4Address.HasValue)
                 {
                     return IPv4Address.GetHashCode();
                 }
@@ -620,7 +536,7 @@ namespace Benchmarks.Libs
                 && FirstV6Leg == other.FirstV6Leg
                 && LastV6Leg == other.LastV6Leg;
 
-            public override bool Equals(object? obj)
+            public override bool Equals(object obj)
             {
                 if (obj is null)
                 {
@@ -633,16 +549,16 @@ namespace Benchmarks.Libs
 
             private static int Compare(TinyIPAddress a, TinyIPAddress b)
             {
-                if (a.IsV4 && b.IsV4)
+                if (a.IPv4Address.HasValue && b.IPv4Address.HasValue)
                 {
-                    return a.IPv4Address.CompareTo(b.IPv4Address);
+                    return a.IPv4Address.Value.CompareTo(b.IPv4Address.Value);
                 }
-                var flc = a.FirstV6Leg.CompareTo(b.FirstV6Leg);
+                var flc = a.FirstV6Leg.Value.CompareTo(b.FirstV6Leg.Value);
                 if (flc != 0)
                 {
                     return flc;
                 }
-                return a.LastV6Leg.CompareTo(b.LastV6Leg);
+                return a.LastV6Leg.Value.CompareTo(b.LastV6Leg.Value);
             }
         }
     }

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -46,7 +46,7 @@ namespace Benchmarks
         public Config()
         {
             Add(MemoryDiagnoser.Default);
-            Add(Job.Default.With(ClrRuntime.Net472));
+            //Add(Job.Default.With(ClrRuntime.Net472));
             Add(Job.Default.With(CoreRuntime.Core31));
             //Add(new InliningDiagnoser());
         }

--- a/Benchmarks/String.Interpolation.cs
+++ b/Benchmarks/String.Interpolation.cs
@@ -1,0 +1,26 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks
+{
+    [Config(typeof(Config))]
+    public class InterpolationTests
+    {
+        private readonly int num = 5;
+        private readonly string str = "test";
+
+        private readonly int num2 = 5;
+        private readonly string str2 = "test";
+        private readonly string str3 = "test";
+        private readonly string str4 = "test";
+
+        [Benchmark]
+        public string IntBoxing() => $"Some {num} thing {str}";
+        [Benchmark]
+        public string IntToString() => $"Some {num.ToString()} thing {str}";
+
+        [Benchmark]
+        public string IntBoxingMoreArgs() => $"Some {num} thing {str} {num2} {str2} {str3} {str4}";
+        [Benchmark]
+        public string IntToStringMoreArgs() => $"Some {num.ToString()} thing {str} {num2.ToString()} {str2} {str3} {str4}";
+    }
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <LangVersion>Latest</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/Profiling/Profiling.csproj
+++ b/Profiling/Profiling.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Benchmarks/Benchmarks.csproj" />
+  </ItemGroup>
+</Project>

--- a/Profiling/Program.cs
+++ b/Profiling/Program.cs
@@ -1,0 +1,28 @@
+﻿using Benchmarks.Libs;
+using System.Diagnostics;
+using static System.Console;
+
+namespace Benchmarks
+{
+    public static class Program
+    {
+        const int loops = 50_000_000;
+
+        public static void Main(string[] args)
+        {
+            WriteLine("Press any key to begin");
+            ReadKey();
+
+            WriteLine("Running Loop ({0} iteations)...", loops);
+            var sw = Stopwatch.StartNew();
+            for (var i = 0; i < loops; i++)
+            {
+                IPNet.Parse("127.0.0.1/16");
+            }
+            sw.Stop();
+            WriteLine("Done: " + sw.ElapsedMilliseconds + " ms");
+            //WriteLine("Press any key to exit");
+            //ReadKey();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ To run any class of benchmark, all that's needed is the class name of the benchm
 ```
 dotner build
 cd Benchmarks
-dotnet run -c Release --framework netcoreapp2.1 -- Regex
+dotnet run -c Release --framework netcoreapp3.1 -- Regex
 ```
 Without the `-- Regex` argument, a list will be presented like this:
 ```
-λ dotnet run -c Release --framework netcoreapp2.1
+λ dotnet run -c Release --framework netcoreapp3.1
 Please, select benchmark, list of available:
 Allocation
 Conditional
@@ -35,4 +35,4 @@ So that others may benefit, I've created a repo to maintain here, rather than on
 
 If you have any questions, I'm usually available in realtime at [@Nick_Craver](https://twitter.com/Nick_Craver)
 
-Note: The repo uses the new Visual Studio 2017 minimal `.csproj` format.
+Note: The repo uses the new Visual Studio 2019 minimal `.csproj` format.

--- a/Tests/IPNetTests.cs
+++ b/Tests/IPNetTests.cs
@@ -1,0 +1,165 @@
+﻿using Benchmarks.Libs;
+using System.Net;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests
+{
+    public class IPNetTests
+    {
+        private ITestOutputHelper log { get; }
+        public IPNetTests(ITestOutputHelper output) => log = output;
+
+        // TODO: IPV6 tests
+        [Theory]
+        [InlineData("127.1", true, "127.0.0.1", "127.0.0.1", true)]
+        [InlineData("127.0.1", true, "127.0.0.1", "127.0.0.1", true)]
+        [InlineData("127.0.0.1", true, "127.0.0.1", "127.0.0.1", true)]
+        [InlineData("127.1/32", true, "127.0.0.1", "127.0.0.1", true)]
+        [InlineData("127.0.1/32", true, "127.0.0.1", "127.0.0.1", true)]
+        [InlineData("127.0.0.1/32", true, "127.0.0.1", "127.0.0.1", true)]
+
+        [InlineData("127.0.0.1/0", true, "0.0.0.0", "255.255.255.255", false)]
+        [InlineData("127.0.0.1/33", false, null, null, true)]
+        [InlineData("127.0.0.1/64", false, null, null, true)]
+
+        [InlineData("1.1.1.1/16", true, "1.1.0.0", "1.1.255.255", false)]
+        [InlineData("1.1.0.0/16", true, "1.1.0.0", "1.1.255.255", false)]
+        [InlineData("1.1.0.0/23", true, "1.1.0.0", "1.1.1.255", false)]
+        [InlineData("1.1.1.1/24", true, "1.1.1.0", "1.1.1.255", false)]
+        [InlineData("1.1.1.1/31", true, "1.1.1.0", "1.1.1.1", false)]
+
+        [InlineData("::1", true, "::1", "::1", true)]
+        [InlineData("::2", true, "::2", "::2", false)]
+        [InlineData("::ffff:ffff", true, "::ffff:ffff", "::ffff:ffff", false)]
+        [InlineData("::0/32", true, "::0", "0:0:ffff:ffff:ffff:ffff:ffff:ffff", false)]
+        [InlineData("::0/32", true, "0:0:0:0:0:0:0:0", "0:0:ffff:ffff:ffff:ffff:ffff:ffff", false)]
+        [InlineData("::0/64", true, "::0", "::ffff:ffff:ffff:ffff", false)]
+        [InlineData("::0/96", true, "::0", "0:0:0:0:0:0:ffff:ffff", false)]
+        [InlineData("::0/96", true, "0:0:0:0:0:0:0:0", "0:0:0:0:0:0:ffff:ffff", false)]
+
+        [InlineData("0.0.0.0/0", true, "0.0.0.0", "255.255.255.255", false)]
+        [InlineData("0.0.0.0/32", true, "0.0.0.0", "0.0.0.0", false)]
+        [InlineData("localhost", false, null, null, false)]
+        [InlineData("", false, null, null, false)]
+        [InlineData(null, false, null, null, false)]
+        public void TryParse(string input, bool success, string firstIpString, string lastIpString, bool isPrivate)
+        {
+            var parsed = IPNet.TryParse(input, out var ipNet);
+            Assert.Equal(success, parsed);
+            if (parsed)
+            {
+                var firstIp = IPAddress.Parse(firstIpString);
+                var lastIp = IPAddress.Parse(lastIpString);
+                log.WriteLine("Subnet: " + ipNet.Subnet?.ToString());
+                Assert.Equal(firstIp, ipNet.FirstAddressInSubnet);
+                Assert.Equal(lastIp, ipNet.LastAddressInSubnet);
+                Assert.Equal(isPrivate, ipNet.IsPrivate);
+            }
+        }
+
+        [Theory]
+        [InlineData("127.1", 32, true, "127.0.0.1", "127.0.0.1", true)]
+        [InlineData("127.0.1", 32, true, "127.0.0.1", "127.0.0.1", true)]
+        [InlineData("127.0.0.1", 32, true, "127.0.0.1", "127.0.0.1", true)]
+
+        [InlineData("127.0.0.1", 0, true, "0.0.0.0", "255.255.255.255", false)]
+        [InlineData("127.0.0.1", 33, false, null, null, true)]
+        [InlineData("127.0.0.1", 64, false, null, null, true)]
+
+        [InlineData("1.1.1.1", 16, true, "1.1.0.0", "1.1.255.255", false)]
+        [InlineData("1.1.0.0", 16, true, "1.1.0.0", "1.1.255.255", false)]
+        [InlineData("1.1.0.0", 23, true, "1.1.0.0", "1.1.1.255", false)]
+        [InlineData("1.1.1.1", 24, true, "1.1.1.0", "1.1.1.255", false)]
+        [InlineData("1.1.1.1", 31, true, "1.1.1.0", "1.1.1.1", false)]
+
+        [InlineData("::1", 128, true, "::1", "::1", true)]
+        [InlineData("::2", 128, true, "::2", "::2", false)]
+        [InlineData("::ffff:ffff", 128, true, "::ffff:ffff", "::ffff:ffff", false)]
+        [InlineData("::0", 32, true, "::0", "0:0:ffff:ffff:ffff:ffff:ffff:ffff", false)]
+        [InlineData("::0", 32, true, "0:0:0:0:0:0:0:0", "0:0:ffff:ffff:ffff:ffff:ffff:ffff", false)]
+        [InlineData("::0", 64, true, "::0", "::ffff:ffff:ffff:ffff", false)]
+        [InlineData("::0", 96, true, "::0", "0:0:0:0:0:0:ffff:ffff", false)]
+        [InlineData("::0", 96, true, "0:0:0:0:0:0:0:0", "0:0:0:0:0:0:ffff:ffff", false)]
+
+        [InlineData("0.0.0.0", 0, true, "0.0.0.0", "255.255.255.255", false)]
+        [InlineData("0.0.0.0", 32, true, "0.0.0.0", "0.0.0.0", false)]
+        [InlineData("localhost", 32, false, null, null, false)]
+        [InlineData("", 32, false, null, null, false)]
+        [InlineData(null, 32, false, null, null, false)]
+        public void TryParseCidrArg(string input, byte cidr, bool success, string firstIpString, string lastIpString, bool isPrivate)
+        {
+            var parsed = IPNet.TryParse(input, cidr, out var ipNet);
+            Assert.Equal(success, parsed);
+            if (parsed)
+            {
+                var firstIp = IPAddress.Parse(firstIpString);
+                var lastIp = IPAddress.Parse(lastIpString);
+                Assert.Equal(firstIp, ipNet.FirstAddressInSubnet);
+                Assert.Equal(lastIp, ipNet.LastAddressInSubnet);
+                Assert.Equal(isPrivate, ipNet.IsPrivate);
+            }
+        }
+
+        [Theory]
+        [InlineData("127.1", "255.255.255.255", true, "127.0.0.1", "127.0.0.1", true)]
+        [InlineData("127.0.1", "255.255.255.255", true, "127.0.0.1", "127.0.0.1", true)]
+        [InlineData("127.0.0.1", "255.255.255.255", true, "127.0.0.1", "127.0.0.1", true)]
+
+        [InlineData("127.0.0.1", "0.0.0.0", true, "0.0.0.0", "255.255.255.255", false)]
+        [InlineData("127.0.0.1", "255.255.255.256", false, null, null, true)]
+
+        [InlineData("1.1.1.1", "255.255.0.0", true, "1.1.0.0", "1.1.255.255", false)]
+        [InlineData("1.1.0.0", "255.255.0.0", true, "1.1.0.0", "1.1.255.255", false)]
+        [InlineData("1.1.0.0", "255.255.254.0", true, "1.1.0.0", "1.1.1.255", false)]
+        [InlineData("1.1.1.1", "255.255.255.0", true, "1.1.1.0", "1.1.1.255", false)]
+        [InlineData("1.1.1.1", "255.255.255.254", true, "1.1.1.0", "1.1.1.1", false)]
+
+        [InlineData("0.0.0.0", "0.0.0.0", true, "0.0.0.0", "255.255.255.255", false)]
+        [InlineData("0.0.0.0", "255.255.255.255", true, "0.0.0.0", "0.0.0.0", false)]
+        [InlineData("localhost", "255.255.255.255", false, null, null, false)]
+        [InlineData("", "255.255.255.255", false, null, null, false)]
+        [InlineData(null, "255.255.255.255", false, null, null, false)]
+        public void TryParseSubnetArg(string input, string subnet, bool success, string firstIpString, string lastIpString, bool isPrivate)
+        {
+            var parsed = IPNet.TryParse(input, subnet, out var ipNet);
+            Assert.Equal(success, parsed);
+            if (parsed)
+            {
+                var firstIp = IPAddress.Parse(firstIpString);
+                var lastIp = IPAddress.Parse(lastIpString);
+                Assert.Equal(firstIp, ipNet.FirstAddressInSubnet);
+                Assert.Equal(lastIp, ipNet.LastAddressInSubnet);
+                Assert.Equal(isPrivate, ipNet.IsPrivate);
+            }
+        }
+
+        [Theory]
+        [InlineData("127.0.0.0/16", "127.0.0.1", true)]
+        [InlineData("127.0.0.0/16", "127.1.0.1", false)]
+        [InlineData("::1", "::1", true)]
+        [InlineData("::2", "::2", true)]
+        [InlineData("::1", "::2", false)]
+        // TODO: MOAR CASES!
+        public void ContainsNet(string inputStr, string childInputStr, bool shouldContain)
+        {
+            var ipNet = IPNet.Parse(inputStr);
+            var childNet = IPNet.Parse(childInputStr);
+            Assert.Equal(shouldContain, ipNet.Contains(childNet));
+        }
+
+        [Theory]
+        [InlineData("127.0.0.0/16", "127.0.0.1", true)]
+        [InlineData("127.0.0.0/16", "127.1.0.1", false)]
+        [InlineData("::1", "::1", true)]
+        [InlineData("::2", "::2", true)]
+        [InlineData("::1", "::2", false)]
+        // TODO: MOAR CASES!
+        public void ContainsIP(string inputStr, string childInputStr, bool shouldContain)
+        {
+            var ipNet = IPNet.Parse(inputStr);
+            var childNet = IPAddress.Parse(childInputStr);
+            Assert.Equal(shouldContain, ipNet.Contains(childNet));
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Benchmarks/Benchmarks.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Needs a lot more tests for completeness but the basics are in.

`Orig` benchmarks and `Net472` are commented out for speed but easy to pull back in as a comparison.

For benchmarking, from the repo root:
```ps
dotnet run --project .\Benchmarks\Benchmarks.csproj -c Release -f netcoreapp3.1 -- IPNetSpan
```